### PR TITLE
Fix inconsistent branch name in De translation

### DIFF
--- a/de/noswears/tips/04-accidental-commit-master.md
+++ b/de/noswears/tips/04-accidental-commit-master.md
@@ -11,7 +11,7 @@ git branch neuer-branch-name
 # Entferne den letzten Commit vom master
 # und wechsel zum neuen Branch
 git reset HEAD~ --hard
-git checkout some-new-branch-name
+git checkout neuer-branch-name
 # Dein Commit lebt jetzt in dem neuen Branch weiter :)
 ```
 

--- a/de/swears/tips/04-accidental-commit-master.md
+++ b/de/swears/tips/04-accidental-commit-master.md
@@ -11,7 +11,7 @@ git branch neuer-branch-name
 # Entferne den letzten Commit vom master
 # und wechsel zum neuen Branch
 git reset HEAD~ --hard
-git checkout some-new-branch-name
+git checkout neuer-branch-name
 # Dein Commit lebt jetzt in dem neuen Branch weiter :)
 ```
 


### PR DESCRIPTION
In tip number 4, `some-new-branch-name` was translated the first time, but not the second time, so the instructions don't work in the current German translation.