### PR TITLE
Alt path to move a commit to a new branch

### DIFF
--- a/en/swears/tips/04-accidental-commit-master.md
+++ b/en/swears/tips/04-accidental-commit-master.md
@@ -7,10 +7,11 @@ order: 4
 
 ```git
 # create a new branch from the current state of master
-git branch some-new-branch-name
+git checkout -b some-new-branch-name
+git checkout -
 # remove the last commit from the master branch
 git reset HEAD~ --hard
-git checkout some-new-branch-name
+git checkout -
 # your commit lives in this branch now :)
 ```
 


### PR DESCRIPTION
Uses `git checkout -` to checkout the previous branch.
It uses one more step but could be less typing.