### PR TITLE
Add --force to `git checkout master`

### DIFF
--- a/en/swears/tips/20-fuck-this-noise.md
+++ b/en/swears/tips/20-fuck-this-noise.md
@@ -15,13 +15,12 @@ cd fucking-git-repo-dir
 
 Thanks to Eric V. for this one. All complaints about the use of `sudo` in this joke can be directed to him. 
 
-
 For real though, if your branch is sooo borked that you need to reset the state of your repo to be the same as the remote repo in a "git-approved" way, try this, but beware these are destructive and unrecoverable actions!
 
 ```git
 # get the lastest state of origin
 git fetch origin
-git checkout master
+git checkout --force master
 git reset --hard origin/master
 # delete untracked files and directories
 git clean -d --force


### PR DESCRIPTION
In case ther are files existing in the current directory which would be overwritten by a checkout, `git checkout` refuses to work. The command line parameter `--force` helps here.