### PR TITLE
Fix a typo in Polish translation

### DIFF
--- a/pl/noswears/partials/intro.njk
+++ b/pl/noswears/partials/intro.njk
@@ -1,7 +1,7 @@
 <section class="intro">
     {# {%include "partials/carbonads.njk"%} #}
 
-    <p>Git jest trudny: łatwo coś popsuć, a rozgryzienie tego, jak naprawić błędy jest niemożliwe. Dokumentacja Gita to taki paradoks kury i jajka: nie jesteś w stanie znaleźć instrukcji, jak wygrzebać się z bałanu, <em>jeżeli nie wiesz, jak nazywa się to coś, o czym powinieneś wiedzieć</em>, żeby rozwiązać Twój problem.</p>
+    <p>Git jest trudny: łatwo coś popsuć, a rozgryzienie tego, jak naprawić błędy jest niemożliwe. Dokumentacja Gita to taki paradoks kury i jajka: nie jesteś w stanie znaleźć instrukcji, jak wygrzebać się z bałaganu, <em>jeżeli nie wiesz, jak nazywa się to coś, o czym powinieneś wiedzieć</em>, żeby rozwiązać Twój problem.</p>
 
     <p>Oto niektóre złe sytuacje, w które zdarzyło mi się wpakować oraz instrukcje jak z nich wyjść, wyłożone <i>prostym językiem</i>.</p>
 </section>


### PR DESCRIPTION
There's no such thing as 'bałan'. 'Bałagan' is a whole different story.