### PR TITLE
fix: remove swears for the noswear content

### DIFF
--- a/bn/noswears/tips/20-fuck-this-noise.md
+++ b/bn/noswears/tips/20-fuck-this-noise.md
@@ -8,9 +8,9 @@ order: 20
 
 ```git
 cd ..
-sudo rm -r stupid-git-repo-dir
-git clone https://some.github.url/stupid-git-repo-dir.git
-cd stupid-git-repo-dir
+sudo rm -r annoying-git-repo-dir
+git clone https://some.github.url/annoying-git-repo-dir.git
+cd annoying-git-repo-dir
 ```
 
 ধন্যবাদ Eric V. এটার জন্য. `sudo` ব্যবহার সম্পর্কে সমস্ত অভিযোগই তাঁর কাছে ফরওয়ার্ড করা যেতে পারে। 

--- a/en/noswears/tips/20-fuck-this-noise.md
+++ b/en/noswears/tips/20-fuck-this-noise.md
@@ -8,9 +8,9 @@ order: 20
 
 ```git
 cd ..
-sudo rm -r stupid-git-repo-dir
-git clone https://some.github.url/stupid-git-repo-dir.git
-cd stupid-git-repo-dir
+sudo rm -r annoying-git-repo-dir
+git clone https://some.github.url/annoying-git-repo-dir.git
+cd annoying-git-repo-dir
 ```
 
 Thanks to Eric V. for this one. All complaints about the use of `sudo` in this joke can be directed to him. 

--- a/es/noswears/tips/20-fuck-this-noise.md
+++ b/es/noswears/tips/20-fuck-this-noise.md
@@ -8,9 +8,9 @@ order: 20
 
 ```git
 cd ..
-sudo rm -r stupid-git-repo-dir
-git clone https://some.github.url/stupid-git-repo-dir.git
-cd stupid-git-repo-dir
+sudo rm -r annoying-git-repo-dir
+git clone https://some.github.url/annoying-git-repo-dir.git
+cd annoying-git-repo-dir
 ```
 
 Gracias a Eric V. por esta. Todas las quejas por el uso de `sudo` en este chiste pueden ser dirigidas a él.

--- a/fa/noswears/tips/20-fuck-this-noise.md
+++ b/fa/noswears/tips/20-fuck-this-noise.md
@@ -8,9 +8,9 @@ order: 20
 
 ```git
 cd ..
-sudo rm -r stupid-git-repo-dir
-git clone https://some.github.url/stupid-git-repo-dir.git
-cd stupid-git-repo-dir
+sudo rm -r annoying-git-repo-dir
+git clone https://some.github.url/annoying-git-repo-dir.git
+cd annoying-git-repo-dir
 ```
 
 با تشکر از Eric V. برای این موارد. همه شکایت ها در مورد استفاده از `sudo` در این طنز به او بر می گردد. 

--- a/he/noswears/tips/20-fuck-this-noise.md
+++ b/he/noswears/tips/20-fuck-this-noise.md
@@ -8,9 +8,9 @@ order: 20
 
 ```git
 cd ..
-sudo rm -r stupid-git-repo-dir
-git clone https://some.github.url/stupid-git-repo-dir.git
-cd stupid-git-repo-dir
+sudo rm -r annoying-git-repo-dir
+git clone https://some.github.url/annoying-git-repo-dir.git
+cd annoying-git-repo-dir
 ```
 <div class="rtl">
 תודה ל

--- a/hi/noswears/tips/20-fuck-this-noise.md
+++ b/hi/noswears/tips/20-fuck-this-noise.md
@@ -8,9 +8,9 @@ order: 20
 
 ```git
 cd ..
-sudo rm -r stupid-git-repo-dir
-git clone https://some.github.url/stupid-git-repo-dir.git
-cd stupid-git-repo-dir
+sudo rm -r annoying-git-repo-dir
+git clone https://some.github.url/annoying-git-repo-dir.git
+cd annoying-git-repo-dir
 ```
 
 इसके लिए एरिक वी को धन्यवाद। इस मजाक में `sudo` के उपयोग की सभी शिकायतें उसे निर्देशित की जा सकती हैं। 

--- a/it/noswears/tips/20-fuck-this-noise.md
+++ b/it/noswears/tips/20-fuck-this-noise.md
@@ -8,9 +8,9 @@ order: 20
 
 ```git
 cd ..
-sudo rm -r stupida-git-repo
-git clone https://some.github.url/stupida-git-repo.git
-cd stupida-git-repo-dir
+sudo rm -r fastidiosa-git-repo
+git clone https://some.github.url/fastidiosa-git-repo.git
+cd fastidiosa-git-repo-dir
 ```
 
 Grazie a Eric V. per questa dritta. Tutti le lamentele riguardo l'uso di `sudo` possono essere rivolte a lui.

--- a/ja/noswears/tips/20-fuck-this-noise.md
+++ b/ja/noswears/tips/20-fuck-this-noise.md
@@ -8,9 +8,9 @@ order: 20
 
 ```git
 cd ..
-sudo rm -r fucking-git-repo-dir
-git clone https://some.github.url/fucking-git-repo-dir.git
-cd fucking-git-repo-dir
+sudo rm -r annoying-git-repo-dir
+git clone https://some.github.url/annoying-git-repo-dir.git
+cd annoying-git-repo-dir
 ```
 
 Eric V、これありがとね。仮にこのジョークを真に受けて *sudo* しちゃったとしても、みんな文句は彼に言うんだよ。

--- a/ko/noswears/tips/20-fuck-this-noise.md
+++ b/ko/noswears/tips/20-fuck-this-noise.md
@@ -8,9 +8,9 @@ order: 20
 
 ```git
 cd ..
-sudo rm -r fucking-git-repo-dir
-git clone https://some.github.url/fucking-git-repo-dir.git
-cd fucking-git-repo-dir
+sudo rm -r annoying-git-repo-dir
+git clone https://some.github.url/annoying-git-repo-dir.git
+cd annoying-git-repo-dir
 ```
 
 Eric V. 가 이 방법(장난)을 알려줬다. 그러니 `sudo`를 쓰는 것에 대해서 불평하고 싶다면 부디 그에게 하기를.

--- a/ro/noswears/tips/20-fuck-this-noise.md
+++ b/ro/noswears/tips/20-fuck-this-noise.md
@@ -8,9 +8,9 @@ order: 20
 
 ```git
 cd ..
-sudo rm -r git-repo-dir-stupid
-git clone https://some.github.url/git-repo-dir-stupid.git
-cd git-repo-dir-stupid
+sudo rm -r git-repo-dir-annoying
+git clone https://some.github.url/git-repo-dir-annoying.git
+cd git-repo-dir-annoying
 ```
 
 Mulțumesc lui Eric V. pentru asta. Toate plângerile despre folosirea lui `sudo` în această glumă îi pot fi adresate lui.

--- a/sr/noswears/tips/20-fuck-this-noise.md
+++ b/sr/noswears/tips/20-fuck-this-noise.md
@@ -8,9 +8,9 @@ order: 20
 
 ```git
 cd ..
-sudo rm -r stupid-git-repo-dir
-git clone https://some.github.url/stupid-git-repo-dir.git
-cd stupid-git-repo-dir
+sudo rm -r annoying-git-repo-dir
+git clone https://some.github.url/annoying-git-repo-dir.git
+cd annoying-git-repo-dir
 ```
 
 Hvala Eric V. za ovo. Sve pritužbe na korištenje `sudo`-a u ovoj šali mogu se usmjeriti na njega. 

--- a/th/noswears/tips/20-fuck-this-noise.md
+++ b/th/noswears/tips/20-fuck-this-noise.md
@@ -8,9 +8,9 @@ order: 20
 
 ```git
 cd ..
-sudo rm -r stupid-git-repo-dir
-git clone https://some.github.url/stupid-git-repo-dir.git
-cd stupid-git-repo-dir
+sudo rm -r annoying-git-repo-dir
+git clone https://some.github.url/annoying-git-repo-dir.git
+cd annoying-git-repo-dir
 ```
 
 ขอบคุณ  Eric V. สำหรับคำแนะนำ ถ้าจะโวยว่าทำไมต้องใช้  `sudo` ในมุกนี้ โวยตรงไปที่ Eric V. ได้เลย

--- a/zh/noswears/tips/20-fuck-this-noise.md
+++ b/zh/noswears/tips/20-fuck-this-noise.md
@@ -8,9 +8,9 @@ order: 20
 
 ```git
 cd ..
-sudo rm -r fucking-git-repo-dir
-git clone https://some.github.url/fucking-git-repo-dir.git
-cd fucking-git-repo-dir
+sudo rm -r annoying-git-repo-dir
+git clone https://some.github.url/annoying-git-repo-dir.git
+cd annoying-git-repo-dir
 ```
 
 感谢 Eric V. 提供了这个事例，如果对 `sudo` 的使用有什么的质疑的话，可以去向他提出。


### PR DESCRIPTION
Hi @ksylor,

This patch removed swears in the git command of noswear content. Apart from the f-word, I replaced the word `stupid` with `annoying` because of its pejorative appreciation in some cases.

Cheers,
Zhihui
P.S. I would also suggest renaming file names like `en/noswears/tips/20-fuck-this-noise.md` and its corresponding id, however, changing file names is not allowed in this repo according to your contributing guidelines. 