### PR TITLE
Added Norwegian (bokmål) translation

### DIFF
--- a/_data/site.js
+++ b/_data/site.js
@@ -148,6 +148,11 @@ module.exports = {
             code: "fi",
             arialabel: "Valitse kieli",
         },
+        {
+            label: "norsk bokmål",
+            code: "no_NB",
+            arialabel: "Se på andre språk",
+        },
     ],
     collaborators: [
         {
@@ -289,6 +294,11 @@ module.exports = {
             name: "Senja Jarva",
             link: "https://github.com/sjarva",
             lang: "fi",
+        },
+        {
+            name: "Trond Kjetil Bremnes",
+            link: "https://tk.bremnes.online",
+            lang: "no_NB",
         },
     ],
     otherhelpers: [

--- a/no_NB/noswears/index.html
+++ b/no_NB/noswears/index.html
@@ -1,0 +1,6 @@
+---
+layout: layouts/page.njk
+locale: no_NB
+contentType: noswears
+title: Søren tute, Git!?!
+---

--- a/no_NB/noswears/partials/footer.njk
+++ b/no_NB/noswears/partials/footer.njk
@@ -1,0 +1,5 @@
+<footer>
+    <small class="contact">Hva er ditt Søren tute, git-øyeblikk? Del det med meg!</small>
+    <small class="twitter">{% twitter_link "ksylor" %}</small>
+    <small class="copyright">{{site.copyright | safe}}</small>
+</footer>

--- a/no_NB/noswears/partials/intro.njk
+++ b/no_NB/noswears/partials/intro.njk
@@ -1,0 +1,3 @@
+<p>Git er vanskelig: det er lett å dumme seg ut, og å finne ut hvordan man retter opp i sine feil er helt umulig. Likesom med høna og egget har Git-dokumentasjonen et problem hvor det er umulig å finne ut hvordan man skal komme seg ut av ens rot,<em>med mindre du allerede vet navnet på tingen du trenger å vite om</em> for å fikse problemet ditt.</p>
+
+<p>Så her er noen kjipe situasjoner jeg har havna i, og måten jeg til slutt kom meg ut av de på, <em>på godt norsk</em>.</p>

--- a/no_NB/noswears/partials/outro.njk
+++ b/no_NB/noswears/partials/outro.njk
@@ -1,0 +1,1 @@
+<p>*Ansvarsfraskrivelse: Denne siden er ikke ment som en fullstending referanse. Ja, det finnes andre måter å gjøre de samme tingene med mer teoretisk renhet eller noe sånt, men jeg har kommet frem til disse stegene via prøving og feiling og masse banning og bordkasting, og jeg hadde den snodige ideen å dele de med en solid dose lettbeinthet og bannskap. Ta det som det er!</p>

--- a/no_NB/noswears/partials/thanks.njk
+++ b/no_NB/noswears/partials/thanks.njk
@@ -1,0 +1,4 @@
+<p>Tusen takk til alle som har bidratt til å oversette siden til nye språk, dere er nydelige!
+{% include "partials/collaborator-list.njk" %}. Med ytterligere helpt fra {% include "partials/otherhelper-list.njk" %}</p>
+
+<p>Om du ønsker å bidra en oversettelse til ditt språk, send inn en PR på {% github_link %}</p>

--- a/no_NB/noswears/tips/01-magic-time-machine.md
+++ b/no_NB/noswears/tips/01-magic-time-machine.md
@@ -1,0 +1,18 @@
+---
+tags: tip
+title: Søren tute, jeg gjorde noe helt fryktelig feil, vær så snill å si at git har en magisk tidsmaskin!?!
+id: magic-time-machine
+order: 1
+---
+
+```git
+git reflog
+# du vil se en liste over alle ting du har
+# gjort i git, på tvers av alle brancher!
+# hver enkelt har en index HEAD@{index}
+# finn den som ligger før du kræsja alt sammen
+git reset HEAD@{index}
+# magisk tidsmaskin
+```
+
+Du kan bruke dette for å hente tilbake ting du sletta ved et uhell, eller bare fjerne ting du teste som endte opp med å kræsje repoet, eller for å hente deg inn etter en dårlig merge, eller bare returnere til et tidspunkt hvor ting faktisk funka. Jeg bruker `reflog` MASSE. Supertusen takk til de mange mange mange mange mange som foreslo å legge det til!

--- a/no_NB/noswears/tips/02-change-last-commit.md
+++ b/no_NB/noswears/tips/02-change-last-commit.md
@@ -1,0 +1,18 @@
+---
+tags: tip
+title: Søren tute, jeg committa og innså umiddelbart at jeg trenger gjøre en liten endring!
+id: change-last-commit
+order: 2
+---
+
+```git
+# gjør din enddring
+git add . # eller legg til enkeltfiler
+git commit --amend --no-edit
+# siste commit inneholder nå endringa
+# ADVARSEL: bruk aldri amend på offentlige committer
+```
+
+Dette skjer meg vanligvis når jeg committer, og deretter kjører tester/lintere... og fillern, jeg glemte et mellomrom etter et likhetstegn. Du kan og gjøre endringa som en ny commit og deretter gjøre `rebase -i` for å squashe de sammen, men dette er cirka en million ganger raskere.
+
+*Advarsel: Du bør aldri amende en commit som har blitt pushet til en offentlig/delt branch. Bare bruk amend på committer som kun eksisterer på din lokale kopi, ellers vil du gå kjipe tider i møte.*

--- a/no_NB/noswears/tips/03-change-last-commit-message.md
+++ b/no_NB/noswears/tips/03-change-last-commit-message.md
@@ -1,0 +1,12 @@
+---
+tags: tip
+title: Søren tute, jeg må endre meldinga på forrige commit!
+id: change-last-commit-message
+order: 3
+---
+```git
+git commit --amend
+# følg instruksene for å endre commit-meldinga
+```
+
+Dustete commitmeldingsformatteringskrav.

--- a/no_NB/noswears/tips/04-accidental-commit-master.md
+++ b/no_NB/noswears/tips/04-accidental-commit-master.md
@@ -1,0 +1,17 @@
+---
+tags: tip
+title: Søren tute, jeg kom i skade for å committe noe til main som skulle ha vært på en helt ny branch!
+id: accidental-commit-master
+order: 4
+---
+
+```git
+# skap ny brach fra nåværende tilstand til main
+git branch nytt-branch-navn
+# fjern siste commit fra main-branchen
+git reset HEAD~ --hard
+git checkout nytt-branch-navn
+# committen din bor på denne branchen nå :)
+```
+
+Merk: dette virker ikke om du allerede har pusha committen til en offentlig/delt branch, og om du har prøvd andre ting først, så må du muligens gjøre `git reset HEAD@{antall-committer-tilbake}` istedenfor `HEAD~`. Uendelig tristesse. Til slutt, mange mange mange folk foreslo en knall måte å forkorte dette på som jeg ikke kjente til selv. Tusen takk, alle!

--- a/no_NB/noswears/tips/05-accidental-commit-wrong-branch.md
+++ b/no_NB/noswears/tips/05-accidental-commit-wrong-branch.md
@@ -1,0 +1,29 @@
+---
+tags: tip
+title: Søren tute, jeg committa til feil branch!
+id: accidental-commit-wrong-branch
+order: 5
+---
+
+```git
+# angre forrige commit, men la endringene bli igjen
+git reset HEAD~ --soft
+git stash
+# flytt deg til riktig branch
+git checkout navnet-til-riktig-branch
+git stash pop
+git add . # eller legg til enkeltfiler
+git commit -m "din melding her";
+# endringene dine er nå på riktig branch
+```
+
+Mange folk har foreslått å bruke `cherry-pick` til denne situasjonen óg, så velg den måten som gir mest mening for deg!
+
+```git
+git checkout navnet-til-riktig-branch
+# hent siste commit til main
+git cherry-pick main
+# slett den fra main
+git checkout main
+git reset HEAD~ --hard
+```

--- a/no_NB/noswears/tips/06-dude-wheres-my-diff.md
+++ b/no_NB/noswears/tips/06-dude-wheres-my-diff.md
@@ -1,0 +1,14 @@
+---
+tags: tip
+title: Søren tute, jeg prøvde å kjøre en diff, men ingenting skjedde!?
+id: dude-wheres-my-diff
+order: 6
+---
+
+Om du vet du har gjort endringer på filer, men `diff` er tom, så har du antagelig `add`a filene dine til staging og må bruke et spesielt flagg.
+
+```git
+git diff --staged
+```
+
+Arkiver under &macr;\\\_(ツ)\_/&macr; (ja, jeg vet dette er en feature og ikke en bug, men det er utrolig forbløffende og unaturlig første gangen dette skjer deg!)

--- a/no_NB/noswears/tips/07-undo-a-commit.md
+++ b/no_NB/noswears/tips/07-undo-a-commit.md
@@ -1,0 +1,21 @@
+---
+tags: tip
+title: Søren tute, jeg må angre en commit for typ 5 comitter siden!
+id: undo-a-commit
+order: 7
+---
+
+```git
+# finn committen du vil angre
+git log
+# bruk piltastene for å bla opp og ned i historikken
+# når du har funnet committen din, noter deg hashen
+git revert [hash fra forrige steg]
+# git vil opprette en ny commit som angrer denne committen
+# følg instuksene for å endre commitmeldinga.
+# eller bare lagre og commit
+```
+
+Det viser seg at du ikke trenger å spore opp og copy-paste den gamle filas innhold inn i den eksisterende fila for å angre endringer! Om du har committa en bug kan du angre alt på én gang med `revert`.
+
+Du kan óg angre enkeltfiler istedenfor en full commit! Men, selvfølgelig i tro git-ånd, er dette et helt annet sett kommandoer...

--- a/no_NB/noswears/tips/08-undo-a-file.md
+++ b/no_NB/noswears/tips/08-undo-a-file.md
@@ -1,0 +1,18 @@
+---
+tags: tip
+title: Søren tute, jeg må angre mine endringer til en fil!
+id: undo-a-file
+order: 8
+---
+
+```git
+# finn en hash for en commit fra før fila ble endra
+git log
+# bruk piltastene for å bla opp og ned i historikken
+# når du har funnet committen din, noter deg hashen
+git checkout [hash fra forrige steg] -- path/to/file
+# den gamle versjonen av fila vil nå være i din index
+git commit -m "Wow, du trenger ikke copy-paste for å angre"
+```
+
+Da jeg endelig fant ut av denne var det STORT. STORT. S-T-O-R-T. Men seriøst, på hvilken planet gir `checkout --` mening som den beste måten å angre en fil? :hytter-neve-mot-linus-torvalds:

--- a/no_NB/noswears/tips/20-fuck-this-noise.md
+++ b/no_NB/noswears/tips/20-fuck-this-noise.md
@@ -1,0 +1,29 @@
+---
+tags: tip
+title: Fillern ta, jeg gir opp.
+id: forget-this-noise
+note: denne skal altid være den siste i lista, å sette order til 20 gjør at jeg ikke trenger omdøpe/omsortere denne
+order: 20
+---
+
+```git
+cd ..
+sudo rm -r duste-git-repo
+git clone https://en.github.url/duste-git-repo.git
+cd duste-git-repo
+```
+
+Takk til Eric V. for denne. Alle klager på bruk av `sudo` i denne vitsen kan sendes ham.
+
+Seriøst, om branchen din er sååå ødelagt at du trenger nullstille repo-tilstanden til å være den samme som i remote-repoet på en «git-godkjente»-måte, prøv dette, men vær klar over at dette er destruktive og ugjenkallelige handlinger!
+
+
+```git
+# hent siste tilstand fra origin
+git fetch origin
+git checkout main
+git reset --hard origin/main
+# slett usporede filer og kataloger
+git clean -d --force
+# repeter checkout/reset/clean for hver ødelagt branch
+```

--- a/no_NB/noswears/tips/tips.json
+++ b/no_NB/noswears/tips/tips.json
@@ -1,0 +1,1 @@
+{ "permalink": false }

--- a/no_NB/swears/index.html
+++ b/no_NB/swears/index.html
@@ -1,0 +1,6 @@
+---
+layout: layouts/page.njk
+locale: no_NB
+contentType: swears
+title: Åh skitt, Git!?!
+---

--- a/no_NB/swears/partials/banner.njk
+++ b/no_NB/swears/partials/banner.njk
@@ -1,0 +1,1 @@
+<aside class="notice">Heisann! Du kan få samme innhold uten bannskap på <a href="{{site.url_noswears}}/{{locale}}">dangitgit.com</a></aside>

--- a/no_NB/swears/partials/footer.njk
+++ b/no_NB/swears/partials/footer.njk
@@ -1,0 +1,5 @@
+<footer>
+    <small class="contact">Hva er ditt Åh skitt, git-øyeblikk? Del det med meg!</small>
+    <small class="twitter">{% twitter_link "ohshitgit" %} {% twitter_link "ksylor" %}</small>
+    <small class="copyright">{{site.copyright | safe}}</small>
+</footer>

--- a/no_NB/swears/partials/intro.njk
+++ b/no_NB/swears/partials/intro.njk
@@ -1,0 +1,4 @@
+<p>Git er vanskelig: det er lett å drite seg ut, og å finne ut hvordan man retter opp i sine feil er helvetes umulig. Likesom med høna og egget har Git-dokumentasjonen et problem hvor det er umulig å finne ut hvordan man skal komme seg ut av ens rot,
+<em>med mindre du allerede vet navnet på tingen du trenger å vite om</em> for å fikse problemet ditt.</p>
+
+<p>Så her er noen kjipe situasjoner jeg har havna i, og måten jeg til slutt kom meg ut av de på, <em>på godt norsk</em>.</p>

--- a/no_NB/swears/partials/outro.njk
+++ b/no_NB/swears/partials/outro.njk
@@ -1,0 +1,1 @@
+<p>*Ansvarsfraskrivelse: Denne siden er ikke ment som en fullstending referanse. Ja, det finnes andre måter å gjøre de samme tingene med mer teoretisk renhet eller noe sånt, men jeg har kommet frem til disse stegene via prøving og feiling og masse banning og bordkasting, og jeg hadde den snodige ideen å dele de med en solid dose lettbeinthet og bannskap. Ta det som det er!</p>

--- a/no_NB/swears/partials/thanks.njk
+++ b/no_NB/swears/partials/thanks.njk
@@ -1,0 +1,4 @@
+<p>Tusen takk til alle som har bidratt til å oversette siden til nye språk, dere er nydelige!
+{% include "partials/collaborator-list.njk" %}. Med ytterligere help fra {% include "partials/otherhelper-list.njk" %}</p>
+
+<p>Om du ønsker å bidra en oversettelse til ditt språk, send inn en PR på {% github_link %}</p>

--- a/no_NB/swears/tips/01-magic-time-machine.md
+++ b/no_NB/swears/tips/01-magic-time-machine.md
@@ -1,0 +1,18 @@
+---
+tags: tip
+title: Åh skitt, jeg gjorde noe helt fryktelig feil, vær så snill å si at git har en magisk tidsmaskin!?!
+id: magic-time-machine
+order: 1
+---
+
+```git
+git reflog
+# du vil se en liste over alle ting du har
+# gjort i git, på tvers av alle brancher!
+# hver enkelt har en index HEAD@{index}
+# finn den som ligger før du kræsja alt sammen
+git reset HEAD@{index}
+# magisk tidsmaskin
+```
+
+Du kan bruke dette for å hente tilbake ting du sletta ved et uhell, eller bare fjerne ting du teste som endte opp med å kræsje repoet, eller for å hente deg inn etter en dårlig merge, eller bare returnere til et tidspunkt hvor ting faktisk funka. Jeg bruker `reflog` MASSE. Supertusen takk til de mange mange mange mange mange som foreslo å legge det til!

--- a/no_NB/swears/tips/02-change-last-commit.md
+++ b/no_NB/swears/tips/02-change-last-commit.md
@@ -1,0 +1,18 @@
+---
+tags: tip
+title: Åh skitt, jeg committa og innså umiddelbart at jeg trenger gjøre en liten endring!
+id: change-last-commit
+order: 2
+---
+
+```git
+# gjør din enddring
+git add . # eller legg til enkeltfiler
+git commit --amend --no-edit
+# siste commit inneholder nå endringa
+# ADVARSEL: bruk aldri amend på offentlige committer
+```
+
+Dette skjer meg vanligvis når jeg committer, og deretter kjører tester/lintere... og drit og dra, jeg glemte et mellomrom etter et likhetstegn. Du kan og gjøre endringa som en ny commit og deretter gjøre `rebase -i` for å squashe de sammen, men dette er cirka en million ganger raskere.
+
+*Advarsel: Du bør aldri amende en commit som har blitt pushet til en offentlig/delt branch. Bare bruk amend på committer som kun eksisterer på din lokale kopi, ellers vil du gå kjipe tider i møte.*

--- a/no_NB/swears/tips/03-change-last-commit-message.md
+++ b/no_NB/swears/tips/03-change-last-commit-message.md
@@ -1,0 +1,12 @@
+---
+tags: tip
+title: Åh skitt, jeg må endre meldinga på forrige commit!
+id: change-last-commit-message
+order: 3
+---
+```git
+git commit --amend
+# følg instruksene for å endre commit-meldinga
+```
+
+Dustete commitmeldingsformatteringskrav.

--- a/no_NB/swears/tips/04-accidental-commit-master.md
+++ b/no_NB/swears/tips/04-accidental-commit-master.md
@@ -1,0 +1,17 @@
+---
+tags: tip
+title: Åh skitt, jeg kom i skade for å committe noe til main som skulle ha vært på en helt ny branch!
+id: accidental-commit-master
+order: 4
+---
+
+```git
+# skap ny brach fra nåværende tilstand til main
+git branch nytt-branch-navn
+# fjern siste commit fra main-branchen
+git reset HEAD~ --hard
+git checkout nytt-branch-navn
+# committen din bor på denne branchen nå :)
+```
+
+Merk: dette virker ikke om du allerede har pusha committen til en offentlig/delt branch, og om du har prøvd andre ting først, så må du muligens gjøre `git reset HEAD@{antall-committer-tilbake}` istedenfor `HEAD~`. Uendelig tristesse. Til slutt, mange mange mange folk foreslo en knall måte å forkorte dette på som jeg ikke kjente til selv. Tusen takk, alle!

--- a/no_NB/swears/tips/05-accidental-commit-wrong-branch.md
+++ b/no_NB/swears/tips/05-accidental-commit-wrong-branch.md
@@ -1,0 +1,29 @@
+---
+tags: tip
+title: Åh skitt, jeg committa til feil branch!
+id: accidental-commit-wrong-branch
+order: 5
+---
+
+```git
+# angre forrige commit, men la endringene bli igjen
+git reset HEAD~ --soft
+git stash
+# flytt deg til riktig branch
+git checkout navnet-til-riktig-branch
+git stash pop
+git add . # eller legg til enkeltfiler
+git commit -m "din melding her";
+# endringene dine er nå på riktig branch
+```
+
+Mange folk har foreslått å bruke `cherry-pick` til denne situasjonen óg, så velg den måten som gir mest mening for deg!
+
+```git
+git checkout navnet-til-riktig-branch
+# hent siste commit til main
+git cherry-pick main
+# slett den fra main
+git checkout main
+git reset HEAD~ --hard
+```

--- a/no_NB/swears/tips/06-dude-wheres-my-diff.md
+++ b/no_NB/swears/tips/06-dude-wheres-my-diff.md
@@ -1,0 +1,14 @@
+---
+tags: tip
+title: Åh skitt, jeg prøvde å kjøre en diff, men ingenting skjedde!?
+id: dude-wheres-my-diff
+order: 6
+---
+
+Om du vet du har gjort endringer på filer, men `diff` er tom, så har du antagelig `add`a filene dine til staging og må bruke et spesielt flagg.
+
+```git
+git diff --staged
+```
+
+Arkiver under &macr;\\\_(ツ)\_/&macr; (ja, jeg vet dette er en feature og ikke en bug, men det er jævla forbløffende og unaturlig første gangen dette skjer deg!)

--- a/no_NB/swears/tips/07-undo-a-commit.md
+++ b/no_NB/swears/tips/07-undo-a-commit.md
@@ -1,0 +1,21 @@
+---
+tags: tip
+title: Åh skitt, jeg må angre en commit for typ 5 comitter siden!
+id: undo-a-commit
+order: 7
+---
+
+```git
+# finn committen du vil angre
+git log
+# bruk piltastene for å bla opp og ned i historikken
+# når du har funnet committen din, noter deg hashen
+git revert [hash fra forrige steg]
+# git vil opprette en ny commit som angrer denne committen
+# følg instuksene for å endre commitmeldinga.
+# eller bare lagre og commit
+```
+
+Det viser seg at du ikke trenger å spore opp og copy-paste den gamle filas innhold inn i den eksisterende fila for å angre endringer! Om du har committa en bug kan du angre alt på én gang med `revert`.
+
+Du kan óg angre enkeltfiler istedenfor en full commit! Men, selvfølgelig i tro git-ånd, er dette et helt annet sett med jævla kommandoer...

--- a/no_NB/swears/tips/08-undo-a-file.md
+++ b/no_NB/swears/tips/08-undo-a-file.md
@@ -1,0 +1,18 @@
+---
+tags: tip
+title: Åh skitt, jeg må angre mine endringer til en fil!
+id: undo-a-file
+order: 8
+---
+
+```git
+# finn en hash for en commit fra før fila ble endra
+git log
+# bruk piltastene for å bla opp og ned i historikken
+# når du har funnet committen din, noter deg hashen
+git checkout [hash fra forrige steg] -- path/to/file
+# den gamle versjonen av fila vil nå være i din index
+git commit -m "Wow, du trenger ikke copy-paste for å angre"
+```
+
+Da jeg endelig fant ut av denne var det STORT. STORT. S-T-O-R-T. Men seriøst, på hvilken jævla planet gir `checkout --` mening som den beste måten å angre en fil? :hytter-neve-mot-linus-torvalds:

--- a/no_NB/swears/tips/20-fuck-this-noise.md
+++ b/no_NB/swears/tips/20-fuck-this-noise.md
@@ -1,0 +1,29 @@
+---
+tags: tip
+title: Faen ta det her, jeg gir opp.
+id: fuck-this-noise
+note: denne skal altid være den siste i lista, å sette order til 20 gjør at jeg ikke trenger omdøpe/omsortere denne
+order: 20
+---
+
+```git
+cd ..
+sudo rm -r jævla-dritt-git-repo
+git clone https://en.github.url/jævla-dritt-git-repo.git
+cd jævla-dritt-git-repo
+```
+
+Takk til Eric V. for denne. Alle klager på bruk av `sudo` i denne vitsen kan sendes ham.
+
+Seriøst, om branchen din er sååå ødelagt at du trenger nullstille repo-tilstanden til å være den samme som i remote-repoet på en «git-godkjente»-måte, prøv dette, men vær klar over at dette er destruktive og ugjenkallelige handlinger!
+
+
+```git
+# hent siste tilstand fra origin
+git fetch origin
+git checkout main
+git reset --hard origin/main
+# slett usporede filer og kataloger
+git clean -d --force
+# repeter checkout/reset/clean for hver ødelagt branch
+```

--- a/no_NB/swears/tips/tips.json
+++ b/no_NB/swears/tips/tips.json
@@ -1,0 +1,1 @@
+{ "permalink": false }


### PR DESCRIPTION
Adds Norwegian (bokmål) translation to project. Opted to use "norsk bokmål" as the language identity to make room for a "norsk nynorsk" in the future. Could have displayed "bokmål" (and "nynorsk") as a naked value, but I do think this is the more common way of doing this.

Swear word of choice: "Åh, skitt" (lit: Oh shit)
Non-swear word of choice: "Søren tute", (lit: Søren honking, a delightfully silly non-swear probably never used non-ironically).

**PS:** Opted to use the presently more standard `main` as the default branch name. Agree or disagree, most popular code forges now defaults to `main` 🤷🏻‍♂️

**PPS:** Opted to not use my Github, but my personal page as my link.